### PR TITLE
Reply by email subject values

### DIFF
--- a/layouts/partials/reply-by-email.html
+++ b/layouts/partials/reply-by-email.html
@@ -1,10 +1,14 @@
 {{ $email_address := $.Site.Params.reply_by_email_address }}
 {{ $link_text := $.Site.Params.reply_by_email_link_text }}
 {{ $subject := $.Site.Params.reply_by_email_subject_prefix }}
-{{ $subject  = print $subject (trim (or .Title .Plain) " \n\r") }}
+{{ $subject  = print $subject (or .Title ( .Permalink | safeURL )) }}
 
 {{ if in $email_address "@" }}
-  <a class="reply-by-email" href="mailto:{{ $email_address }}?subject={{ $subject | htmlUnescape | truncate 60 }}">{{ or $link_text "Reply by email" }}</a>
+	{{ if .Title }}
+  		<a class="reply-by-email" href="mailto:{{ $email_address }}?subject={{ $subject | htmlUnescape | truncate 60 }}">{{ or $link_text "Reply by email" }}</a>
+	{{ else }}
+		  <a class="reply-by-email" href="mailto:{{ $email_address }}?subject={{ $subject }}">{{ or $link_text "Reply by email" }}</a>
+	{{ end }}
 {{ else }}
   <a class="reply-by-email" href="#">{{ or $link_text "Reply by email" }}</a>
   This blog's owner has not provided a valid email address yet.


### PR DESCRIPTION
I’d like to submit this change which still assigns the post title to the $subject, otherwise it will assign the permalink instead.  This would be more useful for say an all-media or quote post that doesn’t start with traditional plain text, and would make it easier to reference back to the actual link.